### PR TITLE
Fix semdcat SHACL prefixes

### DIFF
--- a/SHACL/FsFSemanticArtefactDistributionShape.ttl
+++ b/SHACL/FsFSemanticArtefactDistributionShape.ttl
@@ -1,5 +1,5 @@
 @prefix :        <http://thisfile> .
-@prefix semdcat: <http://purl.org/semdcat> .
+@prefix semdcat: <http://purl.org/semdcat#> .
 @prefix dash:    <http://datashapes.org/dash#> .
 @prefix dcat:    <http://www.w3.org/ns/dcat#> .
 @prefix dct:     <http://purl.org/dc/terms/> .

--- a/SHACL/FsFSemanticArtefactShape.ttl
+++ b/SHACL/FsFSemanticArtefactShape.ttl
@@ -1,5 +1,5 @@
 @prefix :        <http://thisfile> .
-@prefix semdcat: <http://purl.org/semdcat> .
+@prefix semdcat: <http://purl.org/semdcat#> .
 @prefix dash:    <http://datashapes.org/dash#> .
 @prefix dcat:    <http://www.w3.org/ns/dcat#> .
 @prefix dct:     <http://purl.org/dc/terms/> .


### PR DESCRIPTION
All prefixes should end with either '/' or '#'.
Otherwise things break.